### PR TITLE
Expand CI matrix for different Rails versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0"]
+        ruby-version:
+          - "2.7"
+          - "3.0"
+        rails-version:
+          - "6.1"
+          - "main"
 
+    env:
+      RAILS_VERSION: "${{ matrix.rails-version }}"
+
+    name: ${{ format('Tests (Ruby {0}, Rails {1})', matrix.ruby-version, matrix.rails-version) }}
     runs-on: "ubuntu-latest"
 
     steps:
     - uses: "actions/checkout@v2"
     - uses: "ruby/setup-ruby@v1"
       with:
-        ruby-version: ${{ matrix.ruby }}
+        ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
 
     - run: bin/rails test test/**/*_test.rb
+
+    - name: Fail when generated changes are not checked-in
+      run: |
+        git update-index --refresh
+        git diff-index --quiet HEAD --

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,16 @@ gemspec
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 
-gem "rails", github: "rails/rails"
+rails_version = ENV.fetch("RAILS_VERSION", "6.1")
+
+if rails_version == "main"
+  rails_constraint = { github: "rails/rails" }
+  gem "sprockets-rails"
+else
+  rails_constraint = "~> #{rails_version}.0"
+end
+
+gem "rails", rails_constraint
 
 group :test do
   gem "capybara", '>= 3.26'

--- a/lib/constraint_validations/engine.rb
+++ b/lib/constraint_validations/engine.rb
@@ -59,11 +59,6 @@ module ConstraintValidations
       module ::ActionView
         module Helpers
           module Tags
-            class ActionText
-              prepend AriaTagsExtension
-              prepend ValidationMessageExtension
-            end
-
             class Select
               prepend AriaTagsExtension
               prepend ValidationMessageExtension
@@ -82,6 +77,19 @@ module ConstraintValidations
             [RadioButton, CheckBox].each do |kls|
               kls.prepend CheckableAriaTagsExtension
               kls.prepend ValidationMessageExtension
+            end
+          end
+        end
+      end
+    end
+
+    ActiveSupport.on_load :action_text_rich_text do
+      module ::ActionView
+        module Helpers
+          module Tags
+            class ActionText
+              prepend AriaTagsExtension
+              prepend ValidationMessageExtension
             end
           end
         end

--- a/lib/constraint_validations/form_builder.rb
+++ b/lib/constraint_validations/form_builder.rb
@@ -3,6 +3,10 @@ module ConstraintValidations
     include ConstraintValidations::FormBuilder::Extensions
 
     def self.validation_message_id(template, object_or_name, method, index: nil)
+      if ::ActionView::VERSION::MAJOR < 7
+        template = BackPorts.new(template)
+      end
+
       template.field_id(object_or_name, method, :validation_message, index: index)
     end
 
@@ -11,5 +15,33 @@ module ConstraintValidations
 
       block ? yield(validation_messages) : validation_messages
     end
+
+    class BackPorts < SimpleDelegator
+      #
+      # Implmentation backported from
+      # https://github.com/rails/rails/blob/v7.0.0.alpha2/actionview/lib/action_view/helpers/form_tag_helper.rb#L81-L115
+      #
+      def field_id(object_name, method_name, *suffixes, index: nil)
+        if object_name.respond_to?(:model_name)
+          object_name = object_name.model_name.singular
+        end
+
+        sanitized_object_name = object_name.to_s.gsub(/\]\[|[^-a-zA-Z0-9:.]/, "_").delete_suffix("_")
+
+        sanitized_method_name = method_name.to_s.delete_suffix("?")
+
+        # a little duplication to construct fewer strings
+        if sanitized_object_name.empty?
+          sanitized_method_name
+        elsif suffixes.any?
+          [sanitized_object_name, index, sanitized_method_name, *suffixes].compact.join("_")
+        elsif index
+          "#{sanitized_object_name}_#{index}_#{sanitized_method_name}"
+        else
+          "#{sanitized_object_name}_#{sanitized_method_name}"
+        end
+      end
+    end
+    private_constant :BackPorts
   end
 end

--- a/test/dummy/app/views/messages/new.html.erb
+++ b/test/dummy/app/views/messages/new.html.erb
@@ -23,13 +23,13 @@
 
   <%= form_with model: message, html: { novalidate: true } do |form| %>
     <%= form.validation_message_template do |errors, tag| %>
-      <span <%= tag.attributes({}) %> class="default"><%= errors.to_sentence %></span>
+      <%= tag.span errors.to_sentence, class: "default" %>
     <% end %>
 
     <%= form.label :subject %>
     <%= form.text_field :subject %>
     <%= form.validation_message :subject do |errors, tag| %>
-      <p <%= tag.attributes({}) %> class="customized"><%= errors.to_sentence %></p>
+      <%= tag.p errors.to_sentence, class: "customized" %>
     <% end %>
 
     <%= form.label :content %>


### PR DESCRIPTION
Expand CI matrix for different Rails versions
===
    
First, expand the matrix to incorporate Ruby versions alongside Rails
6.1 and `main`.

Defer Action Text extension
===
    
Defer Action Text extension until `ActionText::RichText` is loaded.
