### PR TITLE
Expand CI Ruby x Rails matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: "CI Tests"
 
 on:
   - "pull_request"
-  - "push"
 
 jobs:
   test:
@@ -12,7 +11,9 @@ jobs:
         ruby-version:
           - "2.7"
           - "3.0"
+          - "3.1"
         rails-version:
+          - "7.0"
           - "6.1"
           - "main"
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,12 +11,12 @@ rails_version = ENV.fetch("RAILS_VERSION", "6.1")
 
 if rails_version == "main"
   rails_constraint = { github: "rails/rails" }
-  gem "sprockets-rails"
 else
   rails_constraint = "~> #{rails_version}.0"
 end
 
 gem "rails", rails_constraint
+gem "sprockets-rails"
 
 group :test do
   gem "capybara", '>= 3.26'


### PR DESCRIPTION
Execute CI against `ruby@3.1` and `rails@7.0`.