### PR TITLE
Improve `fields` and `fields_for` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*   Resolve issues with generating nested `fields` and `fields_for` identifiers.
+
+    *Sean Doyle*

--- a/lib/constraint_validations/engine.rb
+++ b/lib/constraint_validations/engine.rb
@@ -26,8 +26,8 @@ module ConstraintValidations
 
     module ValidationMessageExtension
       def render
-        index = @options.fetch("index", @auto_index)
-        validation_message_id = FormBuilder.validation_message_id(@template_object, @object || @object_name, @method_name, index: index)
+        index = @options.fetch(:index, @auto_index)
+        validation_message_id = FormBuilder.validation_message_id(@template_object, @object_name, @method_name, index: index, namespace: @options[:namespace])
 
         @options["aria-errormessage"] ||= validation_message_id
 

--- a/lib/constraint_validations/form_builder.rb
+++ b/lib/constraint_validations/form_builder.rb
@@ -2,12 +2,12 @@ module ConstraintValidations
   class FormBuilder < ActionView::Helpers::FormBuilder
     include ConstraintValidations::FormBuilder::Extensions
 
-    def self.validation_message_id(template, object_or_name, method, index: nil)
+    def self.validation_message_id(template, object_or_name, method, **options)
       if ::ActionView::VERSION::MAJOR < 7
         template = BackPorts.new(template)
       end
 
-      template.field_id(object_or_name, method, :validation_message, index: index)
+      template.field_id(object_or_name, method, :validation_message, **options)
     end
 
     def self.errors(object, field, &block)
@@ -19,9 +19,9 @@ module ConstraintValidations
     class BackPorts < SimpleDelegator
       #
       # Implmentation backported from
-      # https://github.com/rails/rails/blob/v7.0.0.alpha2/actionview/lib/action_view/helpers/form_tag_helper.rb#L81-L115
+      # https://github.com/rails/rails/blob/v7.0.4.3/actionview/lib/action_view/helpers/form_tag_helper.rb
       #
-      def field_id(object_name, method_name, *suffixes, index: nil)
+      def field_id(object_name, method_name, *suffixes, index: nil, namespace: nil)
         if object_name.respond_to?(:model_name)
           object_name = object_name.model_name.singular
         end
@@ -30,16 +30,13 @@ module ConstraintValidations
 
         sanitized_method_name = method_name.to_s.delete_suffix("?")
 
-        # a little duplication to construct fewer strings
-        if sanitized_object_name.empty?
-          sanitized_method_name
-        elsif suffixes.any?
-          [sanitized_object_name, index, sanitized_method_name, *suffixes].compact.join("_")
-        elsif index
-          "#{sanitized_object_name}_#{index}_#{sanitized_method_name}"
-        else
-          "#{sanitized_object_name}_#{sanitized_method_name}"
-        end
+        [
+          namespace,
+          sanitized_object_name.presence,
+          (index unless sanitized_object_name.empty?),
+          sanitized_method_name,
+          *suffixes,
+        ].tap(&:compact!).join("_")
       end
     end
     private_constant :BackPorts

--- a/lib/constraint_validations/form_builder/extensions.rb
+++ b/lib/constraint_validations/form_builder/extensions.rb
@@ -4,7 +4,13 @@ module ConstraintValidations
       def initialize(*)
         super
 
-        @validation_message_template = proc { |messages, tag| tag.span(messages.to_sentence) }
+        @validation_message_template =
+          if (parent_builder = @options[:parent_builder]) &&
+              (inherited_validation_message_template = parent_builder.instance_values["validation_message_template"])
+            inherited_validation_message_template
+          else
+            proc { |messages, tag| tag.span(messages.to_sentence) }
+          end
       end
 
       # Captures a block for rendering both server- and client-side validation
@@ -84,8 +90,8 @@ module ConstraintValidations
       #
       #   <%= form.text_field :subject, aria: {describedby: form.validation_message_id(:subject)} %>
       #
-      def validation_message_id(field)
-        FormBuilder.validation_message_id(@template, @object, field, index: @index)
+      def validation_message_id(field, index: @index, namespace: @options[:namespace])
+        FormBuilder.validation_message_id(@template, @object_name, field, index: index, namespace: namespace)
       end
 
       # Delegates to the <tt>FormBuilder#object</tt> property when possible, and

--- a/test/dummy/config/locales/en.yml
+++ b/test/dummy/config/locales/en.yml
@@ -31,3 +31,6 @@
 
 en:
   hello: "Hello world"
+  errors:
+    messages:
+      blank: "can't be blank"


### PR DESCRIPTION
Prior to this commit, nested form builders like those constructed by [fields][] and [fields_for][] were not incorporating information like `index:` arguments.

To resolve that  issue, this commit relies on the `@object_name` and the underlying implementation's ability to deconstruct that into the necessary parts, rather then weighing the precedence of the `@object` value.

[fields]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-fields
[fields_for]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-fields_for