### PR TITLE
Extend classes in Zeitwerk-compliant way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*   Extend built-in Action View and Action Text classes with their
+    fully-qualified class names instead of re-opening their modules or classes.
+
+    *Sean Doyle*
+
 *   (Re-)Validate on both `blur` and `input` events. Re-configure those values
     with the `validatesOn:` configuration key.
 

--- a/lib/constraint_validations/engine.rb
+++ b/lib/constraint_validations/engine.rb
@@ -75,43 +75,30 @@ module ConstraintValidations
     end
 
     ActiveSupport.on_load :action_view do
-      module ::ActionView
-        module Helpers
-          module Tags
-            class Select
-              prepend AriaTagsExtension
-              prepend ValidationMessageExtension
-            end
+      [
+        ActionView::Helpers::Tags::Select,
+        ActionView::Helpers::Tags::TextField,
+        ActionView::Helpers::Tags::TextArea,
+      ].each do |klass|
+        klass.prepend AriaTagsExtension
+        klass.prepend ValidationMessageExtension
+      end
 
-            class TextField
-              prepend AriaTagsExtension
-              prepend ValidationMessageExtension
-            end
-
-            class TextArea
-              prepend AriaTagsExtension
-              prepend ValidationMessageExtension
-            end
-
-            [RadioButton, CheckBox].each do |kls|
-              kls.prepend CheckableAriaTagsExtension
-              kls.prepend ValidationMessageExtension
-            end
-          end
-        end
+      [
+        ActionView::Helpers::Tags::RadioButton,
+        ActionView::Helpers::Tags::CheckBox,
+      ].each do |klass|
+        klass.prepend CheckableAriaTagsExtension
+        klass.prepend ValidationMessageExtension
       end
     end
 
     ActiveSupport.on_load :action_text_rich_text do
-      module ::ActionView
-        module Helpers
-          module Tags
-            class ActionText
-              prepend AriaTagsExtension
-              prepend ValidationMessageExtension
-            end
-          end
-        end
+      [
+        ActionView::Helpers::Tags::ActionText,
+      ].each do |klass|
+        klass.prepend AriaTagsExtension
+        klass.prepend ValidationMessageExtension
       end
     end
 


### PR DESCRIPTION
In response to failures like:

```
actiontext/app/helpers/action_text/tag_helper.rb:44:in `<module:Helpers>': superclass mismatch for class ActionText (TypeError)
	from actiontext/app/helpers/action_text/tag_helper.rb:43:in `<main>'
```

Change the Engine to extend built-in Rails classes with fully-qualified class names instead of re-opening, to reduce the risk of superclass mismatches.