### PR TITLE
Eager load classes in `CI=true` environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*   Eager-load classes in `CI=true` environments to guard against Zeitwerk
+    auto-loading issues.
+
+    *Sean Doyle*
+
 *   Extend built-in Action View and Action Text classes with their
     fully-qualified class names instead of re-opening their modules or classes.
 

--- a/lib/constraint_validations/engine.rb
+++ b/lib/constraint_validations/engine.rb
@@ -1,4 +1,6 @@
 require "html5_validators"
+require "html5_validators/active_model/helper_methods"
+require "html5_validators/active_model/validations"
 
 module ConstraintValidations
   class Engine < ::Rails::Engine
@@ -76,17 +78,17 @@ module ConstraintValidations
 
     ActiveSupport.on_load :action_view do
       [
-        ActionView::Helpers::Tags::Select,
-        ActionView::Helpers::Tags::TextField,
-        ActionView::Helpers::Tags::TextArea,
+        ::ActionView::Helpers::Tags::Select,
+        ::ActionView::Helpers::Tags::TextField,
+        ::ActionView::Helpers::Tags::TextArea,
       ].each do |klass|
         klass.prepend AriaTagsExtension
         klass.prepend ValidationMessageExtension
       end
 
       [
-        ActionView::Helpers::Tags::RadioButton,
-        ActionView::Helpers::Tags::CheckBox,
+        ::ActionView::Helpers::Tags::RadioButton,
+        ::ActionView::Helpers::Tags::CheckBox,
       ].each do |klass|
         klass.prepend CheckableAriaTagsExtension
         klass.prepend ValidationMessageExtension

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
Eager-load classes in `CI=true` environments to guard against Zeitwerk auto-loading issues.

In order load the dependent Active Model extensions sooner than the `html5_validators` gem expects, this commit requires them in an initializer, ahead of the `config.after_initialize` hook defined by the `html5_validators` Railtie.