### PR TITLE
Remove Action Text integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*   Drop intended support for Action Text until the engine itself adds test
+    coverage.
+
+    *Sean Doyle*
+
 *   Eager-load classes in `CI=true` environments to guard against Zeitwerk
     auto-loading issues.
 

--- a/lib/constraint_validations/engine.rb
+++ b/lib/constraint_validations/engine.rb
@@ -95,14 +95,6 @@ module ConstraintValidations
       end
     end
 
-    ActiveSupport.on_load :action_text_rich_text do
-      [
-        ActionView::Helpers::Tags::ActionText,
-      ].each do |klass|
-        klass.prepend AriaTagsExtension
-        klass.prepend ValidationMessageExtension
-      end
-    end
 
     ActiveSupport.on_load :action_controller_base do
       default_form_builder ConstraintValidations::FormBuilder


### PR DESCRIPTION
Drop intended support for Action Text until the engine itself adds test coverage.

Without test coverage, it's unclear whether or not the extensions work, or are loaded correctly.