### PR TITLE
Omit `aria-` and `data-` attribute from `input[type="hidden"]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*   Omit `[aria-*]`- and `[data-*]`-prefixed attributes from `[type="hidden"]`
+    fields
+
+    *Sean Doyle*
+
 *   Drop intended support for Action Text until the engine itself adds test
     coverage.
 

--- a/lib/constraint_validations/engine.rb
+++ b/lib/constraint_validations/engine.rb
@@ -23,7 +23,7 @@ module ConstraintValidations
 
     module AriaTagsExtension
       def render
-        if FormBuilder.errors(@object, @method_name).any?
+        if FormBuilder.errors(@object, @method_name).any? && FormBuilder.visible?(self)
           @options["aria-invalid"] ||= "true"
         end
 
@@ -33,7 +33,7 @@ module ConstraintValidations
 
     module CheckableAriaTagsExtension
       def render
-        if FormBuilder.errors(@object, @method_name).any?
+        if FormBuilder.errors(@object, @method_name).any? && FormBuilder.visible?(self)
           @options["aria-invalid"] ||= ("true" if input_checked?(@options))
         end
 
@@ -46,9 +46,11 @@ module ConstraintValidations
         index = @options.fetch(:index, @auto_index)
         validation_message_id = FormBuilder.validation_message_id(@template_object, @object_name, @method_name, index: index, namespace: @options[:namespace])
 
-        @options["aria-errormessage"] ||= validation_message_id
+        if FormBuilder.visible?(self)
+          @options["aria-errormessage"] ||= validation_message_id
+        end
 
-        if @object.present?
+        if @object.present? && FormBuilder.visible?(self)
           config = Rails.configuration.constraint_validations
           source =
             if @object.respond_to?(@method_name)
@@ -60,7 +62,7 @@ module ConstraintValidations
           @options["data-validation-messages"] ||= source.call(**instance_values.to_options).to_json
         end
 
-        if FormBuilder.errors(@object, @method_name).any?
+        if FormBuilder.errors(@object, @method_name).any? && FormBuilder.visible?(self)
           value = @options["aria-describedby"] || @options.dig(:aria, :describedby)
           tokens = value.to_s.split(/\s/)
           tokens.unshift validation_message_id

--- a/lib/constraint_validations/form_builder.rb
+++ b/lib/constraint_validations/form_builder.rb
@@ -16,6 +16,14 @@ module ConstraintValidations
       block ? yield(validation_messages) : validation_messages
     end
 
+    def self.visible?(tag_builder)
+      if tag_builder.class.respond_to?(:field_type)
+        tag_builder.class.field_type != "hidden"
+      else
+        true
+      end
+    end
+
     class BackPorts < SimpleDelegator
       #
       # Implmentation backported from

--- a/test/constraint_validations/tag_extensions_test.rb
+++ b/test/constraint_validations/tag_extensions_test.rb
@@ -35,6 +35,16 @@ class ConstraintValidations::AriaTagExtensionsTest < ActiveSupport::TestCase
     assert_select "input[required][maxlength=?]", "100", count: 1
   end
 
+  test "#render omits Active Model validation message translations from [type=hidden]" do
+    render locals: {message: Message.new}, inline: <<~ERB
+      <%= fields model: message do |form| %>
+        <%= form.hidden_field :content %>
+      <% end %>
+    ERB
+
+    assert_select "input[type=?][data-validation-messages]", "hidden", count: 0
+  end
+
   test "#render encodes Active Model validation message translations" do
     render locals: {message: Message.new}, inline: <<~ERB
       <%= form_with model: message, url: "#" do |form| %>
@@ -70,6 +80,16 @@ class ConstraintValidations::AriaTagExtensionsTest < ActiveSupport::TestCase
 
     assert_select "input[aria-describedby]", count: 0
     assert_select "span[id=?]", "#{@object_name}_content_validation_message", count: 1
+  end
+
+  test "#render omits aria-describedby when the field is [type=hidden]" do
+    render locals: {message: Message.new}, inline: <<~ERB
+      <%= fields model: message do |form| %>
+        <%= form.hidden_field :content %>
+      <% end %>
+    ERB
+
+    assert_select "input[type=?][aria-describedby]", "hidden", count: 0
   end
 
   test "#render encodes aria-describedby reference to the validation message element when the field is invalid" do
@@ -111,6 +131,16 @@ class ConstraintValidations::AriaTagExtensionsTest < ActiveSupport::TestCase
 
     assert_select "input[aria-errormessage~=?]", "namespace_#{@object_name}_content_validation_message", count: 1
     assert_select "span[id=?]", "namespace_#{@object_name}_content_validation_message", count: 1
+  end
+
+  test "#render omits aria-errormessage from [type=hidden]" do
+    render locals: {message: Message.new}, inline: <<~ERB
+      <%= fields model: message do |form| %>
+        <%= form.hidden_field :content %>
+      <% end %>
+    ERB
+
+    assert_select "input[type=?][aria-errormessage]", "hidden", count: 0
   end
 
   test "#render encodes aria-errormessage reference to the validation message element when the field is valid" do
@@ -176,6 +206,18 @@ class ConstraintValidations::AriaTagExtensionsTest < ActiveSupport::TestCase
     ERB
 
     assert_select "input[type=?][aria-invalid=?]", "text", "true", count: 1
+  end
+
+  test "#render omits aria-invalid when the [type=hidden]" do
+    message = Message.new.tap(&:validate)
+
+    render locals: {message: message}, inline: <<~ERB
+      <%= fields model: message do |form| %>
+        <%= form.hidden_field :content %>
+      <% end %>
+    ERB
+
+    assert_select "input[type=?][aria-invalid]", "hidden", count: 0
   end
 
   test "#render sets aria-invalid when the checkbox is checked and the field is invalid" do


### PR DESCRIPTION
Hidden `<input>` elements don't participate in client-side validations in the same way as other form controls. To that end, encoding internationalized validation messages is unnecessary. Similarly, they don't expose their `[aria-errormessage]` or participate in `[aria-describedby]` in the same way as other form controls.

This commit omits those attribute when rendering `<input type="hidden">` elements.