### PR TITLE
Rely on `selenium-webdriver` to manage Chrome in CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,5 @@ group :test do
   gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors", tag: "v0.4.1"
   gem "rexml"
   gem "selenium-webdriver"
-  gem "webdrivers"
   gem "webrick"
 end


### PR DESCRIPTION
Drop dependency on `webdrivers` gem in favor of relying on `selenium-webdriver@>4.10` to manage the installation on our behalf.