### PR TITLE
Fix HTML attribute bug when building `<select>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*   Merge attributes into `@html_options` when available (for example, building
+    `<select>` elements)
+
+    *Sean Doyle*
+
 *   Omit `[aria-*]`- and `[data-*]`-prefixed attributes from `[type="hidden"]`
     fields
 

--- a/lib/constraint_validations/engine.rb
+++ b/lib/constraint_validations/engine.rb
@@ -23,8 +23,15 @@ module ConstraintValidations
 
     module AriaTagsExtension
       def render
+        attributes = @options
+
+        if @html_options.is_a?(Hash)
+          attributes = @html_options
+          attributes.reverse_merge!("required" => @options.delete("required"))
+        end
+
         if FormBuilder.errors(@object, @method_name).any? && FormBuilder.visible?(self)
-          @options["aria-invalid"] ||= "true"
+          attributes["aria-invalid"] ||= "true"
         end
 
         super
@@ -46,8 +53,15 @@ module ConstraintValidations
         index = @options.fetch(:index, @auto_index)
         validation_message_id = FormBuilder.validation_message_id(@template_object, @object_name, @method_name, index: index, namespace: @options[:namespace])
 
+        attributes = @options
+
+        if @html_options.is_a?(Hash)
+          attributes = @html_options
+          attributes.reverse_merge!("required" => @options.delete("required"))
+        end
+
         if FormBuilder.visible?(self)
-          @options["aria-errormessage"] ||= validation_message_id
+          attributes["aria-errormessage"] ||= validation_message_id
         end
 
         if @object.present? && FormBuilder.visible?(self)
@@ -59,18 +73,18 @@ module ConstraintValidations
               config.validation_messages_for_object_name
             end
 
-          @options["data-validation-messages"] ||= source.call(**instance_values.to_options).to_json
+          attributes["data-validation-messages"] ||= source.call(**instance_values.to_options).to_json
         end
 
         if FormBuilder.errors(@object, @method_name).any? && FormBuilder.visible?(self)
-          value = @options["aria-describedby"] || @options.dig(:aria, :describedby)
+          value = attributes["aria-describedby"] || attributes.dig(:aria, :describedby)
           tokens = value.to_s.split(/\s/)
           tokens.unshift validation_message_id
 
-          if @options.dig(:aria, :describedby)
-            @options.deep_merge! aria: { describedby: tokens }
+          if attributes.dig(:aria, :describedby)
+            attributes.deep_merge! aria: { describedby: tokens }
           else
-            @options.merge! "aria-describedby" => tokens.join(" ")
+            attributes.merge! "aria-describedby" => tokens.join(" ")
           end
         end
 

--- a/test/dummy/app/models/message.rb
+++ b/test/dummy/app/models/message.rb
@@ -4,7 +4,9 @@ class Message
 
   attribute :content
   attribute :subject
+  attribute :status
 
   validates :content, presence: true, length: {maximum: 280}
   validates :subject, presence: true, exclusion: {in: %w[forbidden]}
+  validates :status, presence: true
 end

--- a/test/dummy/app/views/messages/new.html.erb
+++ b/test/dummy/app/views/messages/new.html.erb
@@ -8,6 +8,12 @@
       <% end %>
     <% end %>
 
+    <%= form.label :status %>
+    <%= form.select :status, ["published", "draft"], prompt: true %>
+    <% unless params[:skip] %>
+      <%= form.validation_message :status %>
+    <% end %>
+
     <%= form.label :subject %>
     <%= form.text_field :subject %>
     <% unless params[:skip] %>
@@ -30,6 +36,12 @@
 
     <%= form.validation_message_template do |errors, tag| %>
       <%= tag.span errors.to_sentence, class: "default" %>
+    <% end %>
+
+    <%= form.label :status %>
+    <%= form.select :status, ["published", "draft"], prompt: true %>
+    <%= form.validation_message :status do |errors, tag| %>
+      <%= tag.p errors.to_sentence, class: "customized" %>
     <% end %>
 
     <%= form.label :subject %>

--- a/test/system/validations_test.rb
+++ b/test/system/validations_test.rb
@@ -10,6 +10,7 @@ class ValidationsTest < ApplicationSystemTestCase
       send_keys :tab
 
       assert_field "Content", with: "?" * 280
+      assert_field "Status", valid: false, validation_message: "Please select an item in the list."
       assert_field "Subject", valid: false, validation_message: "can't be blank"
       assert_text "can't be blank"
     end
@@ -19,6 +20,7 @@ class ValidationsTest < ApplicationSystemTestCase
     visit new_message_path
 
     within_fieldset "Validate" do
+      select "published", from: "Status"
       fill_in "Subject", with: "forbidden"
       fill_in "Content", with: "not empty"
       click_on "Create Message"
@@ -34,7 +36,8 @@ class ValidationsTest < ApplicationSystemTestCase
     within_fieldset "Validate" do
       click_on "Create Message"
 
-      assert_field "Subject", valid: false, focused: true
+      assert_field "Status", valid: false, focused: true
+      assert_field "Subject", valid: false, focused: false
       assert_field "Content", valid: false, focused: false
     end
   end
@@ -43,9 +46,11 @@ class ValidationsTest < ApplicationSystemTestCase
     visit new_message_path
 
     within_fieldset "Validate" do
+      tab_until_focused :field, "Status"
       tab_until_focused :field, "Subject"
       tab_until_focused :field, "Content"
 
+      assert_field "Status", focused: false, valid: false
       assert_field "Subject", focused: false, valid: false
       assert_field "Content", focused: true
     end
@@ -61,12 +66,15 @@ class ValidationsTest < ApplicationSystemTestCase
       send_keys "valid"
 
       assert_button "Create Message", disabled: true
+      assert_field "Status", validation_message: "can't be blank"
       assert_field "Subject", validation_message: "can't be blank"
 
+      select("published", from: "Status").then { tab_until_focused :field, "Subject" }
       fill_in("Subject", with: "valid").then { tab_until_focused :field, "Content" }
 
       assert_button "Create Message", disabled: false
       assert_no_text "can't be blank"
+      assert_no_field validation_message: "Please select an item in the list."
       assert_no_field validation_message: "can't be blank"
     end
   end
@@ -101,7 +109,7 @@ class NoValidationsTest < ApplicationSystemTestCase
     within_fieldset "Novalidate" do
       click_on "Create Message"
 
-      assert_selector "p.customized", text: "can't be blank"
+      assert_selector "p.customized", text: "can't be blank", count: 2
     end
   end
 end
@@ -115,6 +123,7 @@ class NativeValidationsTest < ApplicationSystemTestCase
       send_keys :tab
 
       assert_no_text "can't be blank"
+      assert_field "Status", valid: false, validation_message: "Please select an item in the list."
       assert_field "Subject", valid: false, validation_message: "Please fill out this field."
     end
   end


### PR DESCRIPTION
While the `@options` instance variable generally represents the HTML attributes for a given form field, building `<select>` elements poses an exception to that rule. Since the final two arguments for [select][] calls are `options = {}, html_options = {}`, the presence of `@html_options` needs to be special-cased.

To account for that, change the monkey patches to utilize an `attributes` local variable that references `@options` when `@html_options` isn't available.

[select]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select