### PR TITLE
Clean-up tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "rails", rails_constraint
 gem "sprockets-rails"
 
 group :test do
-  gem "capybara", '>= 3.26'
+  gem "capybara", ">= 3.26", require: "capybara/minitest"
   gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors", tag: "v0.4.1"
   gem "rexml"
   gem "selenium-webdriver"

--- a/test/constraint_validations/form_builder_test.rb
+++ b/test/constraint_validations/form_builder_test.rb
@@ -1,16 +1,6 @@
 require "test_helper"
 
-class ConstraintValidations::FormBuilderTest < ActiveSupport::TestCase
-  include Rails::Dom::Testing::Assertions
-
-  def render(*arguments, renderer: ApplicationController.renderer, **options, &block)
-    renderer.render(*arguments, **options, &block).tap { |html| @document_root_element = Nokogiri::HTML(html) }
-  end
-
-  def document_root_element
-    @document_root_element.tap { |element| raise "Don't forget to call `render`" if element.nil? }
-  end
-
+class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
   Message = Class.new do
     include ActiveModel::Model
     include ActiveModel::Attributes

--- a/test/constraint_validations/form_builder_test.rb
+++ b/test/constraint_validations/form_builder_test.rb
@@ -20,8 +20,8 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "template[data-validation-message-template]" do
-      assert_select "span[class=?]:empty:not([id])", "errors", count: 1
+    assert_element "template", "data-validation-message-template": true, visible: false do |template|
+      assert_css template, "span:empty", class: "errors", id: false, count: 1
     end
   end
 
@@ -32,8 +32,8 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "template[data-validation-message-template]" do
-      assert_select "span:empty:not([id])", count: 1
+    assert_element "template", "data-validation-message-template": true, visible: false do |template|
+      assert_css template, "span:empty", id: false, count: 1
     end
   end
 
@@ -46,7 +46,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "span[id=?]", "#{@object_name}_content_validation_message", text: "can't be blank", count: 1
+    assert_element "span", id: "#{@object_name}_content_validation_message", text: "can't be blank", count: 1
   end
 
   test "#validation_message renders messages using the form's message template" do
@@ -61,7 +61,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "span[id=?][class=?]", "#{@object_name}_content_validation_message", "error", text: "can't be blank", count: 1
+    assert_element "span", id: "#{@object_name}_content_validation_message", class: "error", text: "can't be blank", count: 1
   end
 
   test "#validation_message renders the validation message id with the namespace" do
@@ -73,7 +73,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "span[id=?]", "namespace_#{@object_name}_content_validation_message", text: "can't be blank", count: 1
+    assert_element "span", id: "namespace_#{@object_name}_content_validation_message", text: "can't be blank", count: 1
   end
 
   test "#validation_message renders messages using the nested form's message template" do
@@ -91,7 +91,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "span[id=?][class=?]", "#{@object_name}_nested_1_content_validation_message", "error", text: "can't be blank", count: 1
+    assert_element "span", id: "#{@object_name}_nested_1_content_validation_message", class: "error", text: "can't be blank", count: 1
   end
 
   test "#validation_message renders messages using the overriding nested form's message template" do
@@ -114,7 +114,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "span[id=?][class=?]", "#{@object_name}_nested_1_content_validation_message", "nested-error", text: "can't be blank", count: 1
+    assert_element "span", id: "#{@object_name}_nested_1_content_validation_message", class: "nested-error", text: "can't be blank", count: 1
   end
 
   test "#validation_message renders via block when provided" do
@@ -128,8 +128,8 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "span", count: 0
-    assert_select "div[id=?][class=?]", "#{@object_name}_content_validation_message", "error", text: "can't be blank", count: 1
+    assert_no_element "span"
+    assert_element "div", id: "#{@object_name}_content_validation_message", class: "error", text: "can't be blank", count: 1
   end
 
   test "#validation_message_id generates a DOM id for the field when invalid" do
@@ -141,7 +141,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "span[id=?]", "#{@object_name}_content_validation_message", count: 1
+    assert_element "span", id: "#{@object_name}_content_validation_message", count: 1
   end
 
   test "#validation_message_id returns the DOM id when the field is valid" do
@@ -153,7 +153,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "span[id=?]", "#{@object_name}_content_validation_message", count: 1
+    assert_element "span", id: "#{@object_name}_content_validation_message", count: 1
   end
 
   test "#errors yields messages to the block" do
@@ -167,7 +167,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "span", text: "can't be blank", count: 1
+    assert_element "span", text: "can't be blank", count: 1
   end
 
   test "#errors returns messages when the block is omitted" do
@@ -179,6 +179,6 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
       <% end %>
     ERB
 
-    assert_select "span", text: "can't be blank", count: 1
+    assert_element "span", text: "can't be blank", count: 1
   end
 end

--- a/test/constraint_validations/form_builder_test.rb
+++ b/test/constraint_validations/form_builder_test.rb
@@ -3,9 +3,8 @@ require "test_helper"
 class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
   Message = Class.new do
     include ActiveModel::Model
-    include ActiveModel::Attributes
 
-    attribute :content
+    attr_accessor :content
 
     validates :content, presence: true
   end

--- a/test/constraint_validations/form_builder_test.rb
+++ b/test/constraint_validations/form_builder_test.rb
@@ -13,7 +13,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
 
   test "#validation_message_template renders a <template> element" do
     render locals: {message: Message.new}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.validation_message_template do |messages, tag| %>
           <%= tag.span messages.to_sentence, class: "errors" %>
         <% end %>
@@ -27,7 +27,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
 
   test "#validation_message_template renders the default template when a block is omitted" do
     render locals: {message: Message.new}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.validation_message_template %>
       <% end %>
     ERB
@@ -41,7 +41,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.validation_message :content %>
       <% end %>
     ERB
@@ -53,7 +53,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.validation_message_template do |messages, tag| %>
           <%= tag.span messages.to_sentence, class: "error" %>
         <% end %>
@@ -68,7 +68,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#", namespace: "namespace" do |form| %>
+      <%= fields model: message, namespace: "namespace" do |form| %>
         <%= form.validation_message :content %>
       <% end %>
     ERB
@@ -80,7 +80,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.validation_message_template do |messages, tag| %>
           <%= tag.span messages.to_sentence, class: "error" %>
         <% end %>
@@ -98,7 +98,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.validation_message_template do |messages, tag| %>
           <%= tag.span messages.to_sentence, class: "error" %>
         <% end %>
@@ -121,7 +121,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <% form.validation_message :content do |messages, tag| %>
           <%= tag.div messages.to_sentence, class: "error" %>
         <% end %>
@@ -136,7 +136,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= tag.span id: form.validation_message_id(:content) %>
       <% end %>
     ERB
@@ -148,7 +148,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
     message = Message.new(content: "no empty!").tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= tag.span id: form.validation_message_id(:content) %>
       <% end %>
     ERB
@@ -160,7 +160,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <% form.errors(:content) do |errors| %>
           <span><%= errors.to_sentence %></span>
         <% end %>
@@ -174,7 +174,7 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <span><%= form.errors(:content).to_sentence %></span>
       <% end %>
     ERB

--- a/test/constraint_validations/tag_extensions_test.rb
+++ b/test/constraint_validations/tag_extensions_test.rb
@@ -1,16 +1,6 @@
 require "test_helper"
 
-class ConstraintValidations::AriaTagExtensionsTest < ActiveSupport::TestCase
-  include Rails::Dom::Testing::Assertions
-
-  def render(*arguments, renderer: ApplicationController.renderer, **options, &block)
-    renderer.render(*arguments, **options, &block).tap { |html| @document_root_element = Nokogiri::HTML(html) }
-  end
-
-  def document_root_element
-    @document_root_element.tap { |element| raise "Don't forget to call `render`" if element.nil? }
-  end
-
+class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::TestCase
   setup { @object_name = "aria_tag_extensions_test_message" }
 
   Message = Class.new do

--- a/test/constraint_validations/tag_extensions_test.rb
+++ b/test/constraint_validations/tag_extensions_test.rb
@@ -5,10 +5,8 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
 
   Message = Class.new do
     include ActiveModel::Model
-    include ActiveModel::Attributes
 
-    attribute :content
-    attribute :published, :boolean
+    attr_accessor :content, :published
 
     validates :content, presence: true, length: {maximum: 100}
     validates :published, presence: true, exclusion: {in: [true]}

--- a/test/constraint_validations/tag_extensions_test.rb
+++ b/test/constraint_validations/tag_extensions_test.rb
@@ -19,8 +19,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[data-validation-messages]", count: 1
-    assert_select "input[required][maxlength=?]", "100", count: 1
+    assert_element "input", required: true, maxlength: 100, "data-validation-messages": true, count: 1
   end
 
   test "#render omits Active Model validation message translations from [type=hidden]" do
@@ -30,7 +29,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[type=?][data-validation-messages]", "hidden", count: 0
+    assert_element "input", type: "hidden", "data-validation-messages": false, visible: false, count: 1
   end
 
   test "#render encodes Active Model validation message translations into text fields" do
@@ -40,11 +39,11 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input", count: 1 do |input, *|
+    assert_field count: 1 do |input|
       messages = JSON.parse(input["data-validation-messages"])
 
-      assert messages["badInput"] = "is invalid"
-      assert messages["valueMissing"] = "can't be blank"
+      assert_equal "is invalid", messages["badInput"]
+      assert_equal "can't be blank", messages["valueMissing"]
     end
   end
 
@@ -55,7 +54,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "select[data-validation-messages]", count: 1 do |select, *|
+    assert_element "select", "data-validation-messages": true, count: 1 do |select|
       messages = JSON.parse(select["data-validation-messages"])
 
       assert_equal "is invalid", messages["badInput"]
@@ -70,7 +69,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[data-validation-messages]", count: 0
+    assert_element "input", "input[data-validation-messages]": false, count: 1
   end
 
   test "#render omits aria-describedby when the field is valid" do
@@ -81,8 +80,8 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[aria-describedby]", count: 0
-    assert_select "span[id=?]", "#{@object_name}_content_validation_message", count: 1
+    assert_element "input", "aria-describedby": false, count: 1
+    assert_element "span", id: "#{@object_name}_content_validation_message", count: 1
   end
 
   test "#render omits aria-describedby when the field is [type=hidden]" do
@@ -92,7 +91,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[type=?][aria-describedby]", "hidden", count: 0
+    assert_element "input", type: "hidden", visible: false, "aria-describedby": false, count: 1
   end
 
   test "#render encodes aria-describedby reference to the validation message element when the text field is invalid" do
@@ -105,8 +104,10 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[aria-describedby~=?]", "#{@object_name}_content_validation_message", count: 1
-    assert_select "span[id=?]", "#{@object_name}_content_validation_message", count: 1
+    assert_element "input", "aria-describedby": "#{@object_name}_content_validation_message", count: 1 do |input|
+      assert_matches_selector input, :field, described_by: "can't be blank"
+    end
+    assert_element "span", id: "#{@object_name}_content_validation_message", count: 1
   end
 
   test "#render encodes aria-describedby reference to the validation message element when the select field is invalid" do
@@ -119,8 +120,10 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "select[aria-describedby~=?]", "#{@object_name}_published_validation_message", count: 1
-    assert_select "span[id=?]", "#{@object_name}_published_validation_message", count: 1
+    assert_element "select", "aria-describedby": "#{@object_name}_published_validation_message" do |select|
+      assert_matches_selector select, :select, described_by: "can't be blank"
+    end
+    assert_element "span", id: "#{@object_name}_published_validation_message", count: 1
   end
 
   test "#render prepends to existing aria-describedby values when the field is invalid" do
@@ -134,8 +137,10 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[aria-describedby~=?]", "#{@object_name}_content_validation_message", count: 1
-    assert_select "input[aria-describedby~=?]", "other_description", count: 1
+    assert_element "input", "aria-describedby": "#{@object_name}_content_validation_message other_description", count: 1 do |input|
+      assert_matches_selector input, :field, described_by: "can't be blank"
+      assert_matches_selector input, :field, described_by: "Optional"
+    end
   end
 
   test "#render encodes aria-errormessage reference into text field with form builder namespace" do
@@ -146,8 +151,8 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[aria-errormessage~=?]", "namespace_#{@object_name}_content_validation_message", count: 1
-    assert_select "span[id=?]", "namespace_#{@object_name}_content_validation_message", count: 1
+    assert_element "input", "aria-errormessage": "namespace_#{@object_name}_content_validation_message", count: 1
+    assert_element "span", id: "namespace_#{@object_name}_content_validation_message", count: 1
   end
 
   test "#render encodes aria-errormessage reference into select with form builder namespace" do
@@ -158,8 +163,8 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "select[aria-errormessage~=?]", "namespace_#{@object_name}_published_validation_message", count: 1
-    assert_select "span[id=?]", "namespace_#{@object_name}_published_validation_message", count: 1
+    assert_element "select", "aria-errormessage": "namespace_#{@object_name}_published_validation_message", count: 1
+    assert_element "span", id: "namespace_#{@object_name}_published_validation_message", count: 1
   end
 
   test "#render omits aria-errormessage from [type=hidden]" do
@@ -169,7 +174,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[type=?][aria-errormessage]", "hidden", count: 0
+    assert_element "input", type: "hidden", "aria-errormessage": false, visible: false, count: 1
   end
 
   test "#render encodes aria-errormessage reference to the validation message element when the field is valid" do
@@ -180,7 +185,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[aria-errormessage~=?]", "#{@object_name}_content_validation_message", count: 1
+    assert_element "input", "aria-errormessage": "#{@object_name}_content_validation_message", count: 1
   end
 
   test "#render encodes aria-errormessage reference to the validation message element when the field is invalid" do
@@ -193,8 +198,8 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[aria-errormessage~=?]", "#{@object_name}_content_validation_message", count: 1
-    assert_select "span[id=?]", "#{@object_name}_content_validation_message", count: 1
+    assert_element "input", "aria-errormessage": "#{@object_name}_content_validation_message", count: 1
+    assert_element "span", id: "#{@object_name}_content_validation_message", count: 1
   end
 
   test "#render encodes aria-errormessage reference with a nested form builder" do
@@ -207,8 +212,8 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[aria-errormessage~=?]", "#{@object_name}_nested_1_content_validation_message", count: 1
-    assert_select "span[id=?]", "#{@object_name}_nested_1_content_validation_message", count: 1
+    assert_element "input", "aria-errormessage": "#{@object_name}_nested_1_content_validation_message", count: 1
+    assert_element "span", id: "#{@object_name}_nested_1_content_validation_message", count: 1
   end
 
   test "#render encodes aria-errormessage reference with a nested form builder's parent's namespace" do
@@ -221,8 +226,8 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[aria-errormessage~=?]", "namespace_#{@object_name}_nested_1_content_validation_message", count: 1
-    assert_select "span[id=?]", "namespace_#{@object_name}_nested_1_content_validation_message", count: 1
+    assert_element "input", "aria-errormessage": "namespace_#{@object_name}_nested_1_content_validation_message", count: 1
+    assert_element "span", id: "namespace_#{@object_name}_nested_1_content_validation_message", count: 1
   end
 
   test "#render sets aria-invalid on the text field when the instance is invalid" do
@@ -234,7 +239,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[type=?][aria-invalid=?]", "text", "true", count: 1
+    assert_element "input", type: "text", "aria-invalid": "true", count: 1
   end
 
   test "#render sets aria-invalid on the select when the instance is invalid" do
@@ -246,7 +251,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "select[required][aria-invalid=?]", "true", count: 1
+    assert_element "select", required: true, "aria-invalid": "true", count: 1
   end
 
   test "#render does not override [required] on the select" do
@@ -258,8 +263,8 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "select:not([required])", count: 1
-    assert_select "select[required]", count: 0
+    assert_element "select", required: false, count: 1
+    assert_no_element "select", required: true
   end
 
   test "#render omits aria-invalid when the [type=hidden]" do
@@ -271,7 +276,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[type=?][aria-invalid]", "hidden", count: 0
+    assert_element "input", type: "hidden", "aria-invalid": false, visible: false, count: 1
   end
 
   test "#render sets aria-invalid when the checkbox is checked and the field is invalid" do
@@ -283,6 +288,8 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "input[checked][type=?][aria-invalid=?]", "checkbox", "true", count: 1
+    assert_checked_field type: "checkbox", count: 1 do |input|
+      assert_matches_selector input, :element, "aria-invalid": "true"
+    end
   end
 end

--- a/test/constraint_validations/tag_extensions_test.rb
+++ b/test/constraint_validations/tag_extensions_test.rb
@@ -14,7 +14,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
 
   test "#render encodes validation attributes onto the element" do
     render locals: {message: Message.new}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.text_field :content %>
       <% end %>
     ERB
@@ -35,7 +35,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
 
   test "#render encodes Active Model validation message translations into text fields" do
     render locals: {message: Message.new}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.text_field :content %>
       <% end %>
     ERB
@@ -55,17 +55,17 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
       <% end %>
     ERB
 
-    assert_select "select", count: 1 do |select, *|
+    assert_select "select[data-validation-messages]", count: 1 do |select, *|
       messages = JSON.parse(select["data-validation-messages"])
 
-      assert messages["badInput"] = "is invalid"
-      assert messages["valueMissing"] = "can't be blank"
+      assert_equal "is invalid", messages["badInput"]
+      assert_equal "can't be blank", messages["valueMissing"]
     end
   end
 
-  test "#render skips validation messages when `form_with model: nil`" do
+  test "#render skips validation messages when `model: nil`" do
     render inline: <<~ERB
-      <%= form_with model: nil, scope: :message, url: "#" do |form| %>
+      <%= fields model: nil, scope: :message do |form| %>
         <%= form.text_field :content %>
       <% end %>
     ERB
@@ -75,7 +75,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
 
   test "#render omits aria-describedby when the field is valid" do
     render locals: {message: Message.new}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.text_field :content %>
         <%= form.validation_message :content %>
       <% end %>
@@ -99,7 +99,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.text_field :content %>
         <%= form.validation_message :content %>
       <% end %>
@@ -127,7 +127,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.text_field :content, aria: { describedby: "other_description" } %>
         <%= form.validation_message :content %>
         <span id="other_description">Optional</span>
@@ -174,7 +174,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
 
   test "#render encodes aria-errormessage reference to the validation message element when the field is valid" do
     render locals: {message: Message.new}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.text_field :content %>
         <%= form.validation_message :content %>
       <% end %>
@@ -187,7 +187,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.text_field :content %>
         <%= form.validation_message :content %>
       <% end %>
@@ -229,7 +229,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
     message = Message.new.tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.text_field :content %>
       <% end %>
     ERB
@@ -278,7 +278,7 @@ class ConstraintValidations::AriaTagExtensionsTest < ConstraintValidations::Test
     message = Message.new(published: true).tap(&:validate)
 
     render locals: {message: message}, inline: <<~ERB
-      <%= form_with model: message, url: "#" do |form| %>
+      <%= fields model: message do |form| %>
         <%= form.check_box :published %>
       <% end %>
     ERB

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,4 +4,16 @@ ENV["RAILS_ENV"] = "test"
 require_relative "../test/dummy/config/environment"
 require "rails/test_help"
 
+class ConstraintValidations::TestCase < ActiveSupport::TestCase
+  include Rails::Dom::Testing::Assertions
 
+  attr_reader :rendered
+
+  def render(*arguments, renderer: ApplicationController.renderer, **options, &block)
+    @rendered = renderer.render(*arguments, **options, &block)
+  end
+
+  def document_root_element
+    Nokogiri::HTML(@rendered).tap { |element| raise "Don't forget to call `render`" if element.nil? }
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require_relative "../test/dummy/config/environment"
 require "rails/test_help"
 
 class ConstraintValidations::TestCase < ActiveSupport::TestCase
-  include Rails::Dom::Testing::Assertions
+  include Capybara::Minitest::Assertions
 
   attr_reader :rendered
 
@@ -15,5 +15,17 @@ class ConstraintValidations::TestCase < ActiveSupport::TestCase
 
   def document_root_element
     Nokogiri::HTML(@rendered).tap { |element| raise "Don't forget to call `render`" if element.nil? }
+  end
+
+  def page
+    Capybara.string(document_root_element)
+  end
+
+  def assert_element(...)
+    assert_selector(:element, ...)
+  end
+
+  def assert_no_element(...)
+    assert_no_selector(:element, ...)
   end
 end


### PR DESCRIPTION
Extract `ConstraintValidations::TestCase`
===

Move the shared `render` and `document_root_element` definitions into a
new `ConstraintValidations::TestCase` class defined in
`test/test_helper.rb`.

Test: Replace `attribute` with `attr_accessor`
===

While `ActiveModel::Attributes` is a powerful module, it isn't necessary
to test `ActiveModel::Model` integration with Action View.

Test: Replace `form_with` with `fields`
===

The tests can utilize `fields` instead of `form_with`. This means that
tests will skip rendering the `<form>` elements, and only render its
contents. As a result, the `url:` option can be omitted.

Test: Migrate to Capybara
===

Re-use Capybara Assertions and Selectors in static HTML tests. Replace
`rails-dom-testing` with `capybara/minitest`.
