### PR TITLE
Add support for Collection `<select>` helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*   Add support for Collection `<select>` helpers
+
+    *Sean Doyle*
+
 *   Merge attributes into `@html_options` when available (for example, building
     `<select>` elements)
 

--- a/lib/constraint_validations/engine.rb
+++ b/lib/constraint_validations/engine.rb
@@ -97,7 +97,11 @@ module ConstraintValidations
         ::ActionView::Helpers::Tags::Select,
         ::ActionView::Helpers::Tags::TextField,
         ::ActionView::Helpers::Tags::TextArea,
-      ].each do |klass|
+        ::ActionView::Helpers::Tags::CollectionSelect,
+        ::ActionView::Helpers::Tags::GroupedCollectionSelect,
+        ::ActionView::Helpers::Tags::TimeZoneSelect,
+        (::ActionView::Helpers::Tags::WeekdaySelect if defined?(::ActionView::Helpers::Tags::WeekdaySelect))
+      ].compact.each do |klass|
         klass.prepend AriaTagsExtension
         klass.prepend ValidationMessageExtension
       end


### PR DESCRIPTION
Support for [collection_select][],
 [grouped_collection_select][], [time_zone_select][], and
[weekday_select][] requires integration in addition to the [select][] support.

[collection_select]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-collection_select
[grouped_collection_select]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-grouped_collection_select
[time_zone_select]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-time_zone_select
[weekday_select]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-weekday_select
[select]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-select