### PR TITLE
Execute CI against Firefox and Chrome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,15 @@ jobs:
           - "7.0"
           - "6.1"
           - "main"
+        selenium-browser:
+          - "headless_chrome"
+          - "headless_firefox"
 
     env:
       RAILS_VERSION: "${{ matrix.rails-version }}"
+      SELENIUM_BROWSER: "${{ matrix.selenium-browser }}"
 
-    name: ${{ format('Tests (Ruby {0}, Rails {1})', matrix.ruby-version, matrix.rails-version) }}
+    name: ${{ format('Tests (Ruby {0}, Rails {1}, Browser {2})', matrix.ruby-version, matrix.rails-version, matrix.selenium-browser) }}
     runs-on: "ubuntu-latest"
 
     steps:

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,7 +4,7 @@ require "capybara"
 Capybara.server = :webrick
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: ENV.fetch("SELENIUM_BROWSER", :headless_chrome).to_sym, screen_size: [1400, 1400]
 
   def tab_until_focused(*arguments, **options, &block)
     using_wait_time false do


### PR DESCRIPTION
Expand CI matrix to incorporate a new `SELENIUM_BROWSER` environment variable that expects either `:headless_chrome` or `:headless_firefox`.