### PR TITLE
Expand CI Matrix to Test against Turbo and Stimulus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        hotwire-enabled:
+          - true
+          - false
         ruby-version:
           - "2.7"
           - "3.0"
@@ -26,7 +29,7 @@ jobs:
       RAILS_VERSION: "${{ matrix.rails-version }}"
       SELENIUM_BROWSER: "${{ matrix.selenium-browser }}"
 
-    name: ${{ format('Tests (Ruby {0}, Rails {1}, Browser {2})', matrix.ruby-version, matrix.rails-version, matrix.selenium-browser) }}
+    name: ${{ format('Tests (Ruby {0}, Rails {1}, Browser {2}, Hotwire {3})', matrix.ruby-version, matrix.rails-version, matrix.selenium-browser, matrix.hotwire-enabled) }}
     runs-on: "ubuntu-latest"
 
     steps:

--- a/test/dummy/app/assets/javascripts/application.js
+++ b/test/dummy/app/assets/javascripts/application.js
@@ -13,7 +13,3 @@
 //= require constraint_validations
 //= require_tree .
 //= require_self
-
-addEventListener("DOMContentLoaded", () => {
-  ConstraintValidations.connect(document, { disableSubmitWhenInvalid: (element) => true })
-})

--- a/test/dummy/app/controllers/messages_controller.rb
+++ b/test/dummy/app/controllers/messages_controller.rb
@@ -4,12 +4,22 @@ class MessagesController < ApplicationController
   end
 
   def create
-    message = Message.new(params.require(:message).permit(:subject, :contents))
+    message = Message.new(message_params)
 
     if message.valid?
-      redirect_back or_to: root_url
+      redirect_to new_message_url(redirect_params)
     else
       render :new, locals: {message: message}, status: :unprocessable_entity
     end
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:status, :subject, :content)
+  end
+
+  def redirect_params
+    params.to_unsafe_h.except(:action, :authenticity_token, :controller, :message)
   end
 end

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -8,6 +8,47 @@
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
+
+    <% case ENV.fetch("HOTWIRE_ENABLED", params[:hotwire_enabled])
+       when "1", /true/i %>
+      <script type="module">
+        import "https://unpkg.com/@hotwired/turbo-rails@7.1.2/app/assets/javascripts/turbo.js"
+        import { Application, Controller } from "https://unpkg.com/@hotwired/stimulus@3.2.2/dist/stimulus.js"
+
+        const application = Application.start()
+
+        application.register("constraint-validations", class extends Controller {
+          static values = { options: Object }
+
+          initialize() {
+            this.validations = new ConstraintValidations(this.element, this.optionsValue)
+          }
+
+          connect() {
+            this.validations.connect()
+          }
+
+          disconnect() {
+            this.validations.disconnect()
+          }
+        })
+      </script>
+    <% else %>
+      <script>
+        addEventListener("DOMContentLoaded", () => {
+          <% case params[:disableSubmitWhenInvalid]
+             when "0", /false/i %>
+          const disableSubmitWhenInvalid = false
+          <% when "1", /true/i %>
+          const disableSubmitWhenInvalid = true
+          <% else %>
+          const disableSubmitWhenInvalid = (element) => true
+          <% end %>
+
+          ConstraintValidations.connect(document, { disableSubmitWhenInvalid })
+        })
+      </script>
+    <% end %>
   </head>
 
   <body>

--- a/test/dummy/app/views/messages/new.html.erb
+++ b/test/dummy/app/views/messages/new.html.erb
@@ -1,4 +1,10 @@
-<%= form_with model: message, namespace: "validate" do |form| %>
+<%= form_with model: message, namespace: "validate", data: {
+      controller: "constraint-validations",
+      constraint_validations_options_value: {disableSubmitWhenInvalid: params[:disableSubmitWhenInvalid] == "true"}
+    } do |form| %>
+  <%= hidden_field_tag :hotwire_enabled, params[:hotwire_enabled] %>
+  <%= hidden_field_tag :disableSubmitWhenInvalid, params[:disableSubmitWhenInvalid] %>
+
   <fieldset>
     <legend>Validate</legend>
 
@@ -30,7 +36,16 @@
   </fieldset>
 <% end %>
 
-<%= form_with model: message, namespace: "novalidate", html: { novalidate: true } do |form| %>
+<%= form_with model: message, namespace: "novalidate", html: {
+      novalidate: true,
+      data: {
+        controller: "constraint-validations",
+        constraint_validations_options_value: {disableSubmitWhenInvalid: params[:disableSubmitWhenInvalid] == "true"}
+      }
+    } do |form| %>
+  <%= hidden_field_tag :hotwire_enabled, params[:hotwire_enabled] %>
+  <%= hidden_field_tag :disableSubmitWhenInvalid, params[:disableSubmitWhenInvalid] %>
+
   <fieldset>
     <legend>Novalidate</legend>
 

--- a/test/system/validations_test.rb
+++ b/test/system/validations_test.rb
@@ -57,7 +57,7 @@ class ValidationsTest < ApplicationSystemTestCase
   end
 
   test "disables the submit button when invalid" do
-    visit new_message_path
+    visit new_message_path(disableSubmitWhenInvalid: true)
 
     within_fieldset "Validate" do
       assert_button "Create Message", disabled: false


### PR DESCRIPTION
Add the `hotwire-enabled` setting to the CI matrix, then map that to the `HOTWIRE_ENABLED` environment variable.

When `HOTWIRE_ENABLED="true"`, render the test page HTML with Turbo and Stimulus integration. Otherwise, render with built-in JavaScript.

In the test harness, incorporate the `hotwire_enabled` query parameter override as a `HOTWIRE_ENABLED` corollary. Similarly, incorporate the `disableSubmitWhenInvalid` query parameter into the `ConstraintValidations` instance configuration.