### PR TITLE
Add System Test coverage for `validateOn:` configuration

### DIFF
--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -36,16 +36,22 @@
     <% else %>
       <script>
         addEventListener("DOMContentLoaded", () => {
+          const options = {}
+
           <% case params[:disableSubmitWhenInvalid]
              when "0", /false/i %>
-          const disableSubmitWhenInvalid = false
+          options.disableSubmitWhenInvalid = false
           <% when "1", /true/i %>
-          const disableSubmitWhenInvalid = true
+          options.disableSubmitWhenInvalid = true
           <% else %>
-          const disableSubmitWhenInvalid = (element) => true
+          options.disableSubmitWhenInvalid = (element) => true
           <% end %>
 
-          ConstraintValidations.connect(document, { disableSubmitWhenInvalid })
+          <% if params[:validateOn] %>
+          options.validateOn = <%= params[:validateOn].to_json.html_safe %>
+          <% end %>
+
+          ConstraintValidations.connect(document, options)
         })
       </script>
     <% end %>

--- a/test/dummy/app/views/messages/new.html.erb
+++ b/test/dummy/app/views/messages/new.html.erb
@@ -1,9 +1,13 @@
 <%= form_with model: message, namespace: "validate", data: {
       controller: "constraint-validations",
-      constraint_validations_options_value: {disableSubmitWhenInvalid: params[:disableSubmitWhenInvalid] == "true"}
+      constraint_validations_options_value: {
+        disableSubmitWhenInvalid: params[:disableSubmitWhenInvalid] == "true",
+        validateOn: params[:validateOn]
+      }.compact
     } do |form| %>
   <%= hidden_field_tag :hotwire_enabled, params[:hotwire_enabled] %>
   <%= hidden_field_tag :disableSubmitWhenInvalid, params[:disableSubmitWhenInvalid] %>
+  <%= hidden_field_tag :validateOn, params[:validateOn] %>
 
   <fieldset>
     <legend>Validate</legend>
@@ -39,13 +43,14 @@
 
 <%= form_with model: message, namespace: "novalidate", html: {
       novalidate: true,
-      data: {
-        controller: "constraint-validations",
-        constraint_validations_options_value: {disableSubmitWhenInvalid: params[:disableSubmitWhenInvalid] == "true"}
-      }
+      constraint_validations_options_value: {
+        disableSubmitWhenInvalid: params[:disableSubmitWhenInvalid] == "true",
+        validateOn: params[:validateOn]
+      }.compact
     } do |form| %>
   <%= hidden_field_tag :hotwire_enabled, params[:hotwire_enabled] %>
   <%= hidden_field_tag :disableSubmitWhenInvalid, params[:disableSubmitWhenInvalid] %>
+  <%= hidden_field_tag :validateOn, params[:validateOn] %>
 
   <fieldset>
     <legend>Novalidate</legend>

--- a/test/system/validations_test.rb
+++ b/test/system/validations_test.rb
@@ -16,6 +16,58 @@ class ValidationsTest < ApplicationSystemTestCase
     end
   end
 
+  test "validates fields on input and blur by default" do
+    visit new_message_path
+
+    within_fieldset "Validate" do
+      tab_until_focused :field, "Subject"
+
+      assert_field "Subject", focused: true, valid: false
+
+      send_keys :tab
+
+      assert_field "Subject", focused: false, valid: false, described_by: "can't be blank"
+
+      send_keys [:shift, :tab]
+
+      assert_field "Subject", focused: true, valid: false, described_by: "can't be blank"
+
+      send_keys "valid"
+
+      assert_field "Subject", focused: true, valid: true
+
+      send_keys :tab
+
+      assert_field "Subject", focused: false, valid: true
+    end
+  end
+
+  test "configures which events to validate after" do
+    visit new_message_path(validateOn: ["blur"])
+
+    within_fieldset "Validate" do
+      tab_until_focused :field, "Subject"
+
+      assert_field "Subject", focused: true, valid: false
+
+      send_keys :tab
+
+      assert_field "Subject", focused: false, valid: false, described_by: "can't be blank"
+
+      send_keys [:shift, :tab]
+
+      assert_field "Subject", focused: true, valid: false, described_by: "can't be blank"
+
+      send_keys "valid"
+
+      assert_field "Subject", focused: true, valid: false, described_by: "can't be blank"
+
+      send_keys :tab
+
+      assert_field "Subject", focused: false, valid: true
+    end
+  end
+
   test "validates fields on the server" do
     visit new_message_path(disableSubmitWhenInvalid: true)
 


### PR DESCRIPTION
Encode `validateOn:` into the `<form>` elements or the `<head>` directly in the same way as the `disableSubmitWhenInvalid:` option.