### PR TITLE
Don't execute CI for `rails@main` and `ruby@2.7` or `ruby@3.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
         selenium-browser:
           - "headless_chrome"
           - "headless_firefox"
+        exclude:
+          - ruby-version: "2.7"
+            rails-version: "main"
+          - ruby-version: "3.0"
+            rails-version: "main"
 
     env:
       RAILS_VERSION: "${{ matrix.rails-version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*   Remove `ruby@2.7`-`rails@main` and `ruby@3.0`-`rails@main` pairings from CI
+    matrix
+
+    *Sean Doyle*
+
 *   Render server-generated custom validation messages during initial error
     reporting
 


### PR DESCRIPTION
The `main` branch of the Rails repository has dropped support for Ruby 2.7 and 3.0.

When testing those pairings in CI, use the [:exclude][] key to skip them.

[:exclude]: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations