### PR TITLE
Resolve issue where `:index` was ignored for multiply-nested forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*   Resolve issue where `:index` was ignored for multiply-nested forms
+
+    *Sean Doyle*
+
 *   Pair calls to [HTMLElement.focus][] with [Element.scrollIntoView][] to
     work-around iOS Safari quirks
 

--- a/lib/constraint_validations/engine.rb
+++ b/lib/constraint_validations/engine.rb
@@ -50,7 +50,7 @@ module ConstraintValidations
 
     module ValidationMessageExtension
       def render
-        index = @options.fetch(:index, @auto_index)
+        index = @options.fetch("index") { @options.fetch(:index, @auto_index) }
         validation_message_id = FormBuilder.validation_message_id(@template_object, @object_name, @method_name, index: index, namespace: @options[:namespace])
 
         attributes = @options

--- a/test/constraint_validations/form_builder_test.rb
+++ b/test/constraint_validations/form_builder_test.rb
@@ -76,6 +76,23 @@ class ConstraintValidations::FormBuilderTest < ConstraintValidations::TestCase
     assert_element "span", id: "namespace_#{@object_name}_content_validation_message", text: "can't be blank", count: 1
   end
 
+  test "#validation_message incorporates :index into deep nesting" do
+    message = Message.new.tap(&:validate)
+
+    render locals: {message: message}, inline: <<~ERB
+      <%= fields model: message do |form| %>
+        <%= form.fields model: message, index: 1, namespace: "child" do |child_form| %>
+          <%= child_form.fields model: message, index: 0, namespace: "grandchild" do |grandchild_form| %>
+            <%= grandchild_form.number_field :content %>
+            <%= grandchild_form.validation_message :content %>
+          <% end %>
+        <% end %>
+      <% end %>
+    ERB
+
+    assert_field described_by: "can't be blank"
+  end
+
   test "#validation_message renders messages using the nested form's message template" do
     message = Message.new.tap(&:validate)
 


### PR DESCRIPTION
When nested more than one layer, the `:index` option was ignored during the pairing of `[id]` and `[aria-describedby]`.