### PR TITLE
Use `importmap` in test environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ end
 
 gem "rails", rails_constraint
 gem "sprockets-rails"
+gem "turbo-rails"
+gem "stimulus-rails"
 
 group :test do
   gem "capybara", ">= 3.26", require: "capybara/minitest"

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -8,12 +8,20 @@
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
-
     <% case ENV.fetch("HOTWIRE_ENABLED", params[:hotwire_enabled])
        when "1", /true/i %>
+      <script type="importmap">
+        {
+          "imports": {
+            "@hotwired/turbo-rails": "<%= asset_path("turbo.js") %>",
+            "@hotwired/stimulus": "<%= asset_path("stimulus.js") %>"
+          }
+        }
+      </script>
+
       <script type="module">
-        import "https://unpkg.com/@hotwired/turbo-rails@7.1.2/app/assets/javascripts/turbo.js"
-        import { Application, Controller } from "https://unpkg.com/@hotwired/stimulus@3.2.2/dist/stimulus.js"
+        import "@hotwired/turbo-rails"
+        import { Application, Controller } from "@hotwired/stimulus"
 
         const application = Application.start()
 

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -11,7 +11,7 @@ require "action_controller/railtie"
 # require "action_mailbox/engine"
 # require "action_text/engine"
 require "action_view/railtie"
-# require "action_cable/engine"
+require "action_cable/engine"
 require "sprockets/railtie"
 require "rails/test_unit/railtie"
 

--- a/test/dummy/config/cable.yml
+++ b/test/dummy/config/cable.yml
@@ -1,0 +1,2 @@
+shared:
+  adapter: async


### PR DESCRIPTION
Depend directly on `turbo-rails` and `stimulus-rails` for the sake of the System Test environment.

Instead of consuming `@hotwired/stimulus` and `@hotwired/turbo-rails` from content distribution networks, rely directly on the vendored assets.