### PR TITLE
Drop end-of-life Ruby and Rails versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,10 @@ jobs:
           - true
           - false
         ruby-version:
-          - "2.7"
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
         rails-version:
-          - "6.1"
-          - "7.0"
           - "7.1"
           - "7.2"
           - "main"
@@ -27,10 +23,6 @@ jobs:
           - "headless_chrome"
           - "headless_firefox"
         exclude:
-          - { ruby-version: "2.7", rails-version: "7.2" }
-          - { ruby-version: "2.7", rails-version: "main" }
-          - { ruby-version: "3.0", rails-version: "7.2" }
-          - { ruby-version: "3.0", rails-version: "main" }
           - { ruby-version: "3.1", rails-version: "main" }
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*   Drop [end-of-life Ruby][] versions 2.7 and 3.0.
+
+    *Sean Doyle*
+
+[end-of-life Ruby]: https://www.ruby-lang.org/en/downloads/branches/
+
+*   Drop [end-of-life Rails][] versions 6.1 and 7.0
+
+    *Sean Doyle*
+
+[end-of-life Rails]: https://rubyonrails.org/maintenance
+
 # 0.1.2 - 2024-10-08
 
 *   Use `Set.add` correctly

--- a/constraint_validations.gemspec
+++ b/constraint_validations.gemspec
@@ -10,13 +10,15 @@ Gem::Specification.new do |spec|
   spec.description = ""
   spec.license     = "MIT"
 
+  spec.required_ruby_version = ">= 3.1.0"
+
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/seanpdoyle/constraint_validations"
   spec.metadata["changelog_uri"] = "https://github.com/seanpdoyle/constraint_validations/blob/main/CHANGELOG.md"
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "actionview", ">= 4.2.0"
-  spec.add_dependency "railties", ">= 4.2.0"
+  spec.add_dependency "actionview", ">= 7.1.0"
+  spec.add_dependency "railties", ">= 7.1.0"
   spec.add_dependency "html5_validators"
 end


### PR DESCRIPTION
Drop end-of-life Ruby versions 2.7 and 3.0. Drop end-of-life Rails versions 6.1 and 7.0.