### PR TITLE
Remove `@seanpdoyle` package name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,11 +277,13 @@ If your application uses Stimulus, declare a [controller][] and invoke
 
 ```javascript
 import { Controller } from "@hotwired/stimulus"
-import ConstraintValidations from "@seanpdoyle/constraint_validations"
+import ConstraintValidations from "constraint_validations"
 
 export default class extends Controller {
+  static values = { options: Object }
+
   initialize() {
-    this.validations = new ConstraintValidations(this.element)
+    this.validations = new ConstraintValidations(this.element, this.optionsValue)
   }
 
   connect() {

--- a/bug_report_template.rb
+++ b/bug_report_template.rb
@@ -125,7 +125,7 @@ __END__
         "imports": {
           "@hotwired/turbo-rails": "<%= asset_path("turbo.js") %>",
           "@hotwired/stimulus": "<%= asset_path("stimulus.js") %>",
-          "@seanpdoyle/constraint_validations": "<%= asset_path("constraint_validations.es.js") %>"
+          "constraint_validations": "<%= asset_path("constraint_validations.es.js") %>"
         }
       }
     </script>
@@ -133,7 +133,7 @@ __END__
     <script type="module">
       import "@hotwired/turbo-rails"
       import { Application, Controller } from "@hotwired/stimulus"
-      import ConstraintValidations from "@seanpdoyle/constraint_validations"
+      import ConstraintValidations from "constraint_validations"
 
       const application = Application.start()
       application.register("constraint-validations", class extends Controller {


### PR DESCRIPTION
Update the `README.md` and `bug_report_template.rb` so that the JavaScript module name omits the `@seanpdoyle` prefix.